### PR TITLE
Feature/better config

### DIFF
--- a/configs/example.toml
+++ b/configs/example.toml
@@ -1,4 +1,4 @@
-[[task]]
+[ls]
 name = "ls"
 cmd = "ls -l /home/cempass"
 autostart = true
@@ -9,7 +9,7 @@ stdout = "/tmp/ls.out"
 stderr = "/tmp/ls.err"
 stopsignal = "TERM"
 
-[[task]]
+[ls-homer]
 name = "ls homer"
 cmd = "ls -l /Users/cempassi/Programming"
 autostart = false
@@ -20,7 +20,7 @@ stopsignal = "TERM"
 stdout = "/tmp/ls_home.out"
 stderr = "/tmp/ls_home.err"
 
-[[task]]
+[ls-test]
 name = "ls test"
 cmd = "ls -l /Users/cempassi/Programming"
 autostart = false

--- a/configs/example.yml
+++ b/configs/example.yml
@@ -1,4 +1,4 @@
-task:
-  - name: foo
-    cmd: echo foo
-    umask: 0o722
+foo:
+  name: foo
+  cmd: echo foo
+  umask: 0o722

--- a/configs/minimal.toml
+++ b/configs/minimal.toml
@@ -1,3 +1,2 @@
-[[task]]
-name = "foo"
+[foo]
 cmd = "echo foo"

--- a/configs/with_autostart.toml
+++ b/configs/with_autostart.toml
@@ -1,4 +1,3 @@
-[[task]]
-name = "foo"
+[foo]
 cmd = "echo foo"
 autostart = true

--- a/configs/with_env.toml
+++ b/configs/with_env.toml
@@ -1,4 +1,4 @@
-[[task]]
+[foo]
 name = "foo"
 cmd = "echo foo"
 env = [ "FOO=bar", "PATH=/bin:/usr/bin"]

--- a/configs/with_exitcodes.toml
+++ b/configs/with_exitcodes.toml
@@ -1,4 +1,3 @@
-[[task]]
-name = "foo"
+[foo]
 cmd = "echo foo"
 exitcodes = [42]

--- a/configs/with_numprocess.toml
+++ b/configs/with_numprocess.toml
@@ -1,4 +1,3 @@
-[[task]]
-name = "foo"
+[foo]
 cmd = "echo foo"
 numprocess = 2

--- a/configs/with_restart.toml
+++ b/configs/with_restart.toml
@@ -1,14 +1,11 @@
-[[task]]
-name = "foo always"
+[foo-always]
 cmd = "echo foo"
 restart = "always"
 
-[[task]]
-name = "foo never"
+[foo-never]
 cmd = "echo foo"
 restart = "never"
 
-[[task]]
-name = "foo on-error"
+[foo-on-error]
 cmd = "echo foo"
 restart = "on-error"

--- a/configs/with_retry.toml
+++ b/configs/with_retry.toml
@@ -1,4 +1,3 @@
-[[task]]
-name = "foo"
+[foo]
 cmd = "echo foo"
 retry = 2

--- a/configs/with_stderr.toml
+++ b/configs/with_stderr.toml
@@ -1,4 +1,3 @@
-[[task]]
-name = "foo"
+[foo]
 cmd = "echo foo"
 stderr = "/tmp/foo.err"

--- a/configs/with_stdout.toml
+++ b/configs/with_stdout.toml
@@ -1,4 +1,3 @@
-[[task]]
-name = "foo"
+[foo]
 cmd = "echo foo"
 stdout = "/tmp/foo.out"

--- a/configs/with_stopdelay.toml
+++ b/configs/with_stopdelay.toml
@@ -1,4 +1,3 @@
-[[task]]
-name = "foo"
+[foo]
 cmd = "echo foo"
 stopdelay = 24

--- a/configs/with_stopsignal.toml
+++ b/configs/with_stopsignal.toml
@@ -1,4 +1,3 @@
-[[task]]
-name = "foo"
+[foo]
 cmd = "echo foo"
 stopsignal = "CONT"

--- a/configs/with_successdelay.toml
+++ b/configs/with_successdelay.toml
@@ -1,4 +1,3 @@
-[[task]]
-name = "foo"
+[foo]
 cmd = "echo foo"
 successdelay = 42

--- a/configs/with_umask.toml
+++ b/configs/with_umask.toml
@@ -1,4 +1,3 @@
-[[task]]
-name = "foo"
+[foo]
 cmd = "echo foo"
 umask = 42 # value are in decimal not octal

--- a/configs/with_workingdir.toml
+++ b/configs/with_workingdir.toml
@@ -1,4 +1,3 @@
-[[task]]
-name = "foo"
+[foo]
 cmd = "echo foo"
 workingdir = "/tmp"

--- a/src/server/reader.rs
+++ b/src/server/reader.rs
@@ -1,18 +1,15 @@
 use super::watcher::Watcher;
 use super::{default, error, relaunch::Relaunch};
 use serde::Deserialize;
+use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::fmt;
 use std::fs;
 
-#[derive(Debug, Deserialize)]
-pub struct ConfigFile {
-    pub task: Vec<ReadTask>,
-}
+pub type ConfigFile = BTreeMap<String, ReadTask>;
 
 #[derive(Debug, Deserialize, Eq, PartialEq, Clone)]
 pub struct ReadTask {
-    pub name: String,
     pub cmd: String,
     pub autostart: Option<bool>,
     pub numprocess: Option<u32>,
@@ -42,8 +39,7 @@ impl fmt::Display for ReadTask {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "name: {}\nCommand: {}\nNumber of processes: {}\nAutostart: {}\nUmask: {:#05o}\nWorking Directory: {}\nStdout: {}\nStderr: {}\nStop signal: {}\nStop delay: {}\nretry: {}\nSuccess Delay: {}\nExit Codes: {:?}\nRestart: {}\nEnv: {:?}",
-            self.name,
+            "Command: {}\nNumber of processes: {}\nAutostart: {}\nUmask: {:#05o}\nWorking Directory: {}\nStdout: {}\nStderr: {}\nStop signal: {}\nStop delay: {}\nretry: {}\nSuccess Delay: {}\nExit Codes: {:?}\nRestart: {}\nEnv: {:?}",
             self.cmd,
             self.numprocess.unwrap_or(default::NUMPROCESS),
             self.autostart.unwrap_or(default::AUTOSTART),

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -37,26 +37,26 @@ impl State {
     pub fn reload(&mut self, watcher: &Watcher) {
         let configfile: ConfigFile = ConfigFile::try_from(watcher).unwrap();
 
-        for task in configfile.task {
-            println!("parsed task: {}", task);
+        for (name, task) in configfile {
+            println!("parsed task: {}\n{}", name, task);
 
             //Si la tache existe deja
-            if let Some(t) = self.tasks.get(&task.name) {
+            if let Some(t) = self.tasks.get(&name) {
                 //Si la tache a ete modifiee
                 if t != &task {
                     //Si la tache est deja en cours de lancement, la relancer, sinon
                     //simplement changer la configuration
-                    if let Some(w) = self.workers.get(&task.name) {
+                    if let Some(w) = self.workers.get(&name) {
                         w.send(Action::Reload(task.clone())).unwrap();
                     }
-                    self.tasks.insert(task.name.clone(), task);
+                    self.tasks.insert(name.clone(), task);
                     //Replace in hashmap and relaunch
                 }
             } else {
                 if task.autostart.unwrap_or(default::AUTOSTART) {
-                    watcher.send(Message::Start(task.name.clone()))
+                    watcher.send(Message::Start(name.clone()))
                 }
-                self.tasks.insert(task.name.clone(), task);
+                self.tasks.insert(name.clone(), task);
             }
         }
     }

--- a/src/server/task.rs
+++ b/src/server/task.rs
@@ -17,7 +17,6 @@ enum AutoRestart {
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Task {
-    pub name: String,
     cmd: Vec<String>,
     numprocess: u32,
     autostart: bool,
@@ -46,7 +45,6 @@ impl TryFrom<&ReadTask> for Task {
 
     fn try_from(readtask: &ReadTask) -> Result<Self, Self::Error> {
         Ok(Self {
-            name: readtask.name.clone(),
             cmd: readtask
                 .cmd
                 .split(' ')


### PR DESCRIPTION
This PR allow to use `map` in config files, example

in yaml
```yaml
foo:
  cmd: echo foo
```
in toml
```toml
[foo]
cmd = "echo foo"
```

1 downside is that `ReadTask` & `Task` don't have `name` in it, but because we are already using a `map` I don't see too much problem

close #38 