### PR TITLE
add logging time

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,24 +7,24 @@ mod client;
 mod server;
 mod shared;
 
-use log::{Level, LevelFilter, SetLoggerError};
+use log::{LevelFilter, SetLoggerError};
 use server::error;
+use shared::logger::LOGGER;
 
 type Result<T> = std::result::Result<T, error::Taskmaster>;
-
-static LOGGER: shared::logger::Simple = shared::logger::Simple {
-    level: Level::Debug,
-};
 
 /// # Errors
 ///
 /// Will return `Err` when failing to initialise `LOGGER`
-pub fn init() -> std::result::Result<(), SetLoggerError> {
+unsafe fn init() -> std::result::Result<(), SetLoggerError> {
+    LOGGER.set_instant(std::time::Instant::now());
     log::set_logger(&LOGGER).map(|()| log::set_max_level(LevelFilter::Debug))
 }
 
 fn main() -> Result<()> {
-    init().unwrap();
+    unsafe {
+        init().unwrap();
+    }
     let cli = cli::generate();
 
     if let Some(matches) = cli.subcommand_matches("server") {

--- a/src/shared/logger.rs
+++ b/src/shared/logger.rs
@@ -1,7 +1,20 @@
 use log::{Level, Metadata, Record};
+use std::time::Instant;
+
+pub static mut LOGGER: Simple = Simple {
+    level: Level::Debug,
+    now: None,
+};
 
 pub struct Simple {
     pub level: Level,
+    now: Option<Instant>,
+}
+
+impl Simple {
+    pub fn set_instant(&mut self, instant: Instant) {
+        self.now = Some(instant);
+    }
 }
 
 impl log::Log for Simple {
@@ -11,7 +24,12 @@ impl log::Log for Simple {
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            println!("{} - {}", record.level(), record.args())
+            println!(
+                "[{:03}] {:5} - {}",
+                self.now.map_or(0, |time| time.elapsed().as_secs()),
+                record.level(),
+                record.args()
+            )
         }
     }
 

--- a/src/shared/logger.rs
+++ b/src/shared/logger.rs
@@ -25,9 +25,9 @@ impl log::Log for Simple {
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
             println!(
-                "[{:03}] {:5} - {}",
-                self.now.map_or(0, |time| time.elapsed().as_secs()),
+                "{:>5}[{:03}]  - {}",
                 record.level(),
+                self.now.map_or(0, |time| time.elapsed().as_secs()),
                 record.args()
             )
         }


### PR DESCRIPTION
add logging interval in logging message

## Example

```log
DEBUG[0000] [ls] Not finished yet!
DEBUG[0000] [ls] Went to sleep
DEBUG[0010] Nothing to be done
DEBUG[0010] [ls] child exited with status exit code: 2
DEBUG[0010] [ls] Finished!
DEBUG[0020] Nothing to be done
DEBUG[0026] received SIGINT, sending Quit message
```

### Why this format

the log format is inspired by [logrus](https://github.com/sirupsen/logrus)

![logrus example](https://camo.githubusercontent.com/369a631bb41ad67da0d3d95423a704319f488049d25eac55ee7295363a7afb81/687474703a2f2f692e696d6775722e636f6d2f505937714d77642e706e67)

the number `n` in `[n]` is the time relative to the start of the program

## Why

I choose this simple way, because:

- rust don't seems to provide a function to format time like `strtime` in `C` in the `std` crate
- to format time we would require to install another deps

## Linked issue

close #51 