### PR TITLE
Feature/merge readtask task

### DIFF
--- a/src/server/default.rs
+++ b/src/server/default.rs
@@ -1,16 +1,54 @@
-use super::relaunch::Relaunch;
+use super::{relaunch::Relaunch, signal::Signal};
 use libc::mode_t;
 
-pub const AUTOSTART: bool = false;
-pub const NUMPROCESS: u32 = 1;
-pub const UMASK: mode_t = 0;
-pub const WORKDIR: &str = ".";
-pub const RELAUNCH_MODE: Relaunch = Relaunch::Never;
-pub const RETRY: u32 = 0;
-pub const EXPECTED_EXIT_CODES: [i32; 1] = [0];
-pub const SUCCESS_DELAY: u32 = 0;
-pub const STOP_SIGNAL: &str = "TERM";
-pub const STOP_DELAY: u32 = 2;
-pub const STDOUT: &str = "/dev/null";
-pub const STDERR: &str = "/dev/null";
-pub const ENV: [String; 0] = [];
+pub fn autostart() -> bool {
+    false
+}
+
+pub fn numprocess() -> u32 {
+    1
+}
+
+pub fn umask() -> mode_t {
+    0
+}
+
+pub fn workdir() -> String {
+    String::from(".")
+}
+
+pub fn relaunch_mode() -> Relaunch {
+    Relaunch::Never
+}
+
+pub fn retry() -> u32 {
+    0
+}
+
+pub fn exit_codes() -> Vec<i32> {
+    vec![0]
+}
+
+pub fn success_delay() -> u32 {
+    0
+}
+
+pub fn stop_signal() -> Signal {
+    Signal::Term
+}
+
+pub fn stop_delay() -> u32 {
+    2
+}
+
+pub fn stdout() -> String {
+    String::from("/dev/null")
+}
+
+pub fn stderr() -> String {
+    String::from("/dev/null")
+}
+
+pub fn env() -> Vec<String> {
+    Vec::new()
+}

--- a/src/server/default.rs
+++ b/src/server/default.rs
@@ -1,5 +1,6 @@
 use super::{relaunch::Relaunch, signal::Signal};
 use libc::mode_t;
+use std::path::PathBuf;
 
 pub fn autostart() -> bool {
     false
@@ -13,8 +14,8 @@ pub fn umask() -> mode_t {
     0
 }
 
-pub fn workdir() -> String {
-    String::from(".")
+pub fn workdir() -> PathBuf {
+    PathBuf::from(".")
 }
 
 pub fn relaunch_mode() -> Relaunch {
@@ -41,12 +42,12 @@ pub fn stop_delay() -> u32 {
     2
 }
 
-pub fn stdout() -> String {
-    String::from("/dev/null")
+pub fn stdout() -> PathBuf {
+    PathBuf::from("/dev/null")
 }
 
-pub fn stderr() -> String {
-    String::from("/dev/null")
+pub fn stderr() -> PathBuf {
+    PathBuf::from("/dev/null")
 }
 
 pub fn env() -> Vec<String> {

--- a/src/server/reader.rs
+++ b/src/server/reader.rs
@@ -1,5 +1,5 @@
 use super::watcher::Watcher;
-use super::{default, error, relaunch::Relaunch};
+use super::{default, error, relaunch::Relaunch, signal::Signal};
 use libc::{gid_t, mode_t, uid_t};
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -12,28 +12,45 @@ pub type ConfigFile = BTreeMap<String, ReadTask>;
 #[derive(Debug, Deserialize, Eq, PartialEq, Clone)]
 pub struct ReadTask {
     pub cmd: String,
-    pub autostart: Option<bool>,
-    pub numprocess: Option<u32>,
 
-    pub umask: Option<mode_t>,
+    #[serde(default = "default::autostart")]
+    pub autostart: bool,
 
-    pub workingdir: Option<String>,
+    #[serde(default = "default::numprocess")]
+    pub numprocess: u32,
 
-    pub stopsignal: Option<String>,
-    pub stopdelay: Option<u32>,
+    #[serde(default = "default::umask")]
+    pub umask: mode_t,
 
-    pub stdout: Option<String>,
-    pub stderr: Option<String>,
+    #[serde(default = "default::workdir")]
+    pub workingdir: String,
 
-    pub retry: Option<u32>,
+    #[serde(default = "default::stop_signal")]
+    pub stopsignal: Signal,
 
-    pub successdelay: Option<u32>,
+    #[serde(default = "default::stop_delay")]
+    pub stopdelay: u32,
 
-    pub exitcodes: Option<Vec<i32>>,
+    #[serde(default = "default::stdout")]
+    pub stdout: String,
 
-    pub restart: Option<Relaunch>,
+    #[serde(default = "default::stderr")]
+    pub stderr: String,
 
-    pub env: Option<Vec<String>>,
+    #[serde(default = "default::retry")]
+    pub retry: u32,
+
+    #[serde(default = "default::success_delay")]
+    pub successdelay: u32,
+
+    #[serde(default = "default::exit_codes")]
+    pub exitcodes: Vec<i32>,
+
+    #[serde(default = "default::relaunch_mode")]
+    pub restart: Relaunch,
+
+    #[serde(default = "default::env")]
+    pub env: Vec<String>,
 
     pub gid: Option<gid_t>,
     pub uid: Option<uid_t>,
@@ -45,26 +62,26 @@ impl fmt::Display for ReadTask {
             f,
             "Command: {}\nNumber of processes: {}\nAutostart: {}\nUmask: {:#05o}\nWorking Directory: {}\nStdout: {}\nStderr: {}\nStop signal: {}\nStop delay: {}\nretry: {}\nSuccess Delay: {}\nExit Codes: {:?}\nRestart: {}\nEnv: {:?}\nPermission: uid: {:?}, gid: {:?}",
             self.cmd,
-            self.numprocess.unwrap_or(default::NUMPROCESS),
-            self.autostart.unwrap_or(default::AUTOSTART),
-            self.umask.unwrap_or(default::UMASK),
-            self.workingdir.as_ref().unwrap_or(&String::from(default::WORKDIR)),
+            self.numprocess,
+            self.autostart,
+            self.umask,
+            self.workingdir,
 
-            self.stdout.as_ref().unwrap_or(&String::from(default::STDOUT)),
-            self.stderr.as_ref().unwrap_or(&String::from(default::STDERR)),
+            self.stdout,
+            self.stderr,
 
-            self.stopsignal.as_ref().unwrap_or(&String::from(default::STOP_SIGNAL)),
-            self.stopdelay.unwrap_or(default::STOP_DELAY),
+            self.stopsignal,
+            self.stopdelay,
 
-            self.retry.unwrap_or(default::RETRY),
+            self.retry,
 
-            self.successdelay.unwrap_or(default::SUCCESS_DELAY),
+            self.successdelay,
 
-            self.exitcodes.as_ref().unwrap_or(&Vec::from(default::EXPECTED_EXIT_CODES)),
+            self.exitcodes,
 
-            self.restart.as_ref().unwrap_or(&default::RELAUNCH_MODE),
+            self.restart,
 
-            self.env.as_ref().unwrap_or(&Vec::from(default::ENV)),
+            self.env,
 
             self.uid,
             self.gid,

--- a/src/server/reader.rs
+++ b/src/server/reader.rs
@@ -6,6 +6,7 @@ use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::fmt;
 use std::fs;
+use std::path::PathBuf;
 
 pub type ConfigFile = BTreeMap<String, ReadTask>;
 
@@ -23,7 +24,7 @@ pub struct ReadTask {
     pub umask: mode_t,
 
     #[serde(default = "default::workdir")]
-    pub workingdir: String,
+    pub workingdir: PathBuf,
 
     #[serde(default = "default::stop_signal")]
     pub stopsignal: Signal,
@@ -32,10 +33,10 @@ pub struct ReadTask {
     pub stopdelay: u32,
 
     #[serde(default = "default::stdout")]
-    pub stdout: String,
+    pub stdout: PathBuf,
 
     #[serde(default = "default::stderr")]
-    pub stderr: String,
+    pub stderr: PathBuf,
 
     #[serde(default = "default::retry")]
     pub retry: u32,
@@ -60,7 +61,7 @@ impl fmt::Display for ReadTask {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
-            "Command: {}\nNumber of processes: {}\nAutostart: {}\nUmask: {:#05o}\nWorking Directory: {}\nStdout: {}\nStderr: {}\nStop signal: {}\nStop delay: {}\nretry: {}\nSuccess Delay: {}\nExit Codes: {:?}\nRestart: {}\nEnv: {:?}\nPermission: uid: {:?}, gid: {:?}",
+            "Command: {}\nNumber of processes: {}\nAutostart: {}\nUmask: {:#05o}\nWorking Directory: {:?}\nStdout: {:?}\nStderr: {:?}\nStop signal: {}\nStop delay: {}\nretry: {}\nSuccess Delay: {}\nExit Codes: {:?}\nRestart: {}\nEnv: {:?}\nPermission: uid: {:?}, gid: {:?}",
             self.cmd,
             self.numprocess,
             self.autostart,

--- a/src/server/relaunch.rs
+++ b/src/server/relaunch.rs
@@ -3,14 +3,14 @@ use std::fmt::{self, Display, Formatter};
 
 #[derive(Debug, Eq, Clone, PartialEq, Deserialize)]
 pub enum Relaunch {
+    #[serde(rename = "never")]
+    Never,
+
     #[serde(rename = "always")]
     Always,
 
     #[serde(rename = "on-error")]
     OnError,
-
-    #[serde(rename = "never")]
-    Never,
 }
 
 impl Display for Relaunch {

--- a/src/server/signal.rs
+++ b/src/server/signal.rs
@@ -11,6 +11,7 @@ use super::{Communication, Message};
 use crate::error;
 
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
 pub enum Signal {
     Hup,
     Int,

--- a/src/server/signal.rs
+++ b/src/server/signal.rs
@@ -1,14 +1,16 @@
+use serde::Deserialize;
 use signal_hook::{
     consts::{SIGHUP, SIGINT},
     iterator::Signals,
 };
+use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 use std::sync::mpsc::Sender;
 
 use super::{Communication, Message};
 use crate::error;
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Deserialize)]
 pub enum Signal {
     Hup,
     Int,
@@ -81,6 +83,45 @@ impl FromStr for Signal {
             "USR2" => Ok(Signal::Usr2),
             &_ => Err(error::Taskmaster::Signal),
         }
+    }
+}
+
+impl Display for Signal {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Signal::Hup => "HUP",
+            Signal::Int => "INT",
+            Signal::Quit => "QUIT",
+            Signal::Ill => "ILL",
+            Signal::Trap => "TRAP",
+            Signal::Abrt => "ABRT",
+            Signal::Emt => "EMT",
+            Signal::Fpe => "FPE",
+            Signal::Kill => "KILL",
+            Signal::Bus => "BUS",
+            Signal::Segv => "SEGV",
+            Signal::Sys => "SYS",
+            Signal::Pipe => "PIPE",
+            Signal::Alrm => "ALRM",
+            Signal::Term => "TERM",
+            Signal::Urg => "URG",
+            Signal::Stop => "STOP",
+            Signal::Tstp => "TSTP",
+            Signal::Cont => "CONT",
+            Signal::Chld => "CHLD",
+            Signal::Ttin => "TTIN",
+            Signal::Ttou => "TTOU",
+            Signal::Io => "IO",
+            Signal::Xcpu => "XCPU",
+            Signal::Xfsz => "XFSZ",
+            Signal::Vtal => "VTAL",
+            Signal::Prof => "PROF",
+            Signal::Winc => "WINC",
+            Signal::Info => "INFO",
+            Signal::Usr1 => "USR1",
+            Signal::Usr2 => "USR2",
+        };
+        write!(f, "{}", s)
     }
 }
 

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -5,7 +5,6 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 use super::worker;
 
 use super::{
-    default,
     reader::{ConfigFile, ReadTask},
     task::Task,
     watcher::Watcher,
@@ -49,7 +48,7 @@ impl State {
                     //Replace in hashmap and relaunch
                 }
             } else {
-                if task.autostart.unwrap_or(default::AUTOSTART) {
+                if task.autostart {
                     log::debug!("asking to start {}", name.clone());
                     watcher.send(Message::Start(name.clone()))
                 }

--- a/src/server/task.rs
+++ b/src/server/task.rs
@@ -73,9 +73,9 @@ impl TryFrom<&ReadTask> for Task {
             stopsignal: readtask.stopsignal.clone(),
             stopdelay: readtask.stopdelay,
 
-            workingdir: PathBuf::from(readtask.workingdir.as_str()),
-            stdout: PathBuf::from(readtask.stdout.as_str()),
-            stderr: PathBuf::from(readtask.stderr.as_str()),
+            workingdir: PathBuf::from(&readtask.workingdir),
+            stdout: PathBuf::from(&readtask.stdout),
+            stderr: PathBuf::from(&readtask.stderr),
         })
     }
 }

--- a/src/server/task.rs
+++ b/src/server/task.rs
@@ -1,5 +1,4 @@
 use libc::{gid_t, mode_t, uid_t};
-use serde::Deserialize;
 use std::convert::TryFrom;
 use std::fs::File;
 use std::os::unix::process::CommandExt;
@@ -8,13 +7,6 @@ use std::process::{Child, Command};
 use std::vec::Vec;
 
 use super::{error, reader::ReadTask, relaunch::Relaunch, signal};
-
-#[derive(Debug, Deserialize)]
-enum AutoRestart {
-    Unexpected,
-    True,
-    False,
-}
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct Task {

--- a/src/server/task.rs
+++ b/src/server/task.rs
@@ -5,10 +5,9 @@ use std::fs::File;
 use std::os::unix::process::CommandExt;
 use std::path::PathBuf;
 use std::process::{Child, Command};
-use std::str::FromStr;
 use std::vec::Vec;
 
-use super::{default, error, reader::ReadTask, relaunch::Relaunch, signal};
+use super::{error, reader::ReadTask, relaunch::Relaunch, signal};
 
 #[derive(Debug, Deserialize)]
 enum AutoRestart {
@@ -54,64 +53,29 @@ impl TryFrom<&ReadTask> for Task {
                 .split(' ')
                 .map(std::string::ToString::to_string)
                 .collect(),
-            numprocess: readtask.numprocess.unwrap_or(default::NUMPROCESS),
-            autostart: readtask.autostart.unwrap_or(default::AUTOSTART),
-            umask: readtask.umask.unwrap_or(default::UMASK),
+            numprocess: readtask.numprocess,
+            autostart: readtask.autostart,
+            umask: readtask.umask,
 
-            retry: readtask.retry.unwrap_or(default::RETRY),
+            retry: readtask.retry,
 
-            successdelay: readtask.successdelay.unwrap_or(default::SUCCESS_DELAY),
+            successdelay: readtask.successdelay,
 
             uid: readtask.uid,
             gid: readtask.gid,
 
-            env: readtask
-                .env
-                .as_ref()
-                .unwrap_or(&Vec::from(default::ENV))
-                .clone(),
+            env: readtask.env.clone(),
 
-            restart: readtask
-                .restart
-                .as_ref()
-                .unwrap_or(&default::RELAUNCH_MODE)
-                .clone(),
+            restart: readtask.restart.clone(),
 
-            expected_exit_codes: readtask
-                .exitcodes
-                .as_ref()
-                .unwrap_or(&Vec::from(default::EXPECTED_EXIT_CODES))
-                .clone(),
+            expected_exit_codes: readtask.exitcodes.clone(),
 
-            stopsignal: signal::Signal::from_str(
-                &readtask
-                    .stopsignal
-                    .as_ref()
-                    .unwrap_or(&String::from(default::STOP_SIGNAL)),
-            )?,
-            stopdelay: readtask.stopdelay.unwrap_or(default::STOP_DELAY),
+            stopsignal: readtask.stopsignal.clone(),
+            stopdelay: readtask.stopdelay,
 
-            workingdir: PathBuf::from(
-                readtask
-                    .workingdir
-                    .as_ref()
-                    .unwrap_or(&String::from(default::WORKDIR))
-                    .as_str(),
-            ),
-            stdout: PathBuf::from(
-                readtask
-                    .stdout
-                    .as_ref()
-                    .unwrap_or(&String::from(default::STDOUT))
-                    .as_str(),
-            ),
-            stderr: PathBuf::from(
-                readtask
-                    .stderr
-                    .as_ref()
-                    .unwrap_or(&String::from(default::STDERR))
-                    .as_str(),
-            ),
+            workingdir: PathBuf::from(readtask.workingdir.as_str()),
+            stdout: PathBuf::from(readtask.stdout.as_str()),
+            stderr: PathBuf::from(readtask.stderr.as_str()),
         })
     }
 }


### PR DESCRIPTION
The goal is to merge `reader::ReadTask` with `task::Task`, because they're alike.

Here is the diff between the 2:

```diff
 struct Task {
-    cmd: Vec<String>,
+    cmd: String,
     numprocess: u32,
     autostart: bool,
     umask: mode_t,
```

children of #62 