### PR TITLE
Feature/allow logging to file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ clap = "~2.27.0"
 termion = "1"
 regex = "1"
 signal-hook = "0.3.8"
-log = "0.4.14"
+log = { version = "0.4.14", features = ["std"] }
 nix = "0.20.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,14 +7,21 @@ pub fn generate() -> ArgMatches<'static> {
         .subcommand(
             SubCommand::with_name("server")
                 .about("Launch server daemon")
-                .arg(
+                .args(&[
                     Arg::with_name("config")
                         .short("c")
+                        .help("use config file")
                         .long("config")
                         .value_name("FILE")
                         .takes_value(true)
                         .required(true),
-                ),
+                    Arg::with_name("log-file")
+                        .default_value("/dev/stderr")
+                        .help("set output logging file")
+                        .long("log-file")
+                        .value_name("FILE")
+                        .takes_value(true),
+                ]),
         )
         .subcommand(SubCommand::with_name("client").about("Launch client"))
         .get_matches()

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -17,7 +17,6 @@ pub fn generate() -> ArgMatches<'static> {
         )
         .subcommand(SubCommand::with_name("client").about("Launch client"))
         .args(&[Arg::with_name("log-file")
-            .default_value("/dev/stderr")
             .help("set output logging file")
             .long("log-file")
             .value_name("FILE")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -7,22 +7,20 @@ pub fn generate() -> ArgMatches<'static> {
         .subcommand(
             SubCommand::with_name("server")
                 .about("Launch server daemon")
-                .args(&[
-                    Arg::with_name("config")
-                        .short("c")
-                        .help("use config file")
-                        .long("config")
-                        .value_name("FILE")
-                        .takes_value(true)
-                        .required(true),
-                    Arg::with_name("log-file")
-                        .default_value("/dev/stderr")
-                        .help("set output logging file")
-                        .long("log-file")
-                        .value_name("FILE")
-                        .takes_value(true),
-                ]),
+                .args(&[Arg::with_name("config")
+                    .short("c")
+                    .help("use config file")
+                    .long("config")
+                    .value_name("FILE")
+                    .takes_value(true)
+                    .required(true)]),
         )
         .subcommand(SubCommand::with_name("client").about("Launch client"))
+        .args(&[Arg::with_name("log-file")
+            .default_value("/dev/stderr")
+            .help("set output logging file")
+            .long("log-file")
+            .value_name("FILE")
+            .takes_value(true)])
         .get_matches()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod shared;
 
 use log::{LevelFilter, SetLoggerError};
 use server::error;
-use shared::logger::simple::LOGGER;
+use shared::logger::Simple;
 
 type Result<T> = std::result::Result<T, error::Taskmaster>;
 
@@ -17,8 +17,7 @@ type Result<T> = std::result::Result<T, error::Taskmaster>;
 ///
 /// Will return `Err` when failing to initialise `LOGGER`
 unsafe fn init() -> std::result::Result<(), SetLoggerError> {
-    LOGGER.set_instant(std::time::Instant::now());
-    log::set_logger(&LOGGER).map(|()| log::set_max_level(LevelFilter::Debug))
+    Simple::init(LevelFilter::Debug)
 }
 
 fn main() -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod shared;
 
 use log::{LevelFilter, SetLoggerError};
 use server::error;
-use shared::logger::LOGGER;
+use shared::logger::simple::LOGGER;
 
 type Result<T> = std::result::Result<T, error::Taskmaster>;
 
@@ -26,6 +26,8 @@ fn main() -> Result<()> {
         init().unwrap();
     }
     let cli = cli::generate();
+
+    // LOGGER.
 
     if let Some(matches) = cli.subcommand_matches("server") {
         let config = matches.value_of("config").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ mod shared;
 
 use log::{LevelFilter, SetLoggerError};
 use server::error;
-use shared::logger::{Config, Simple};
+use shared::logger::{self, Config};
 use std::time;
 
 type Result<T> = std::result::Result<T, error::Taskmaster>;
@@ -17,20 +17,19 @@ type Result<T> = std::result::Result<T, error::Taskmaster>;
 /// # Errors
 ///
 /// Will return `Err` when failing to initialise `LOGGER`
-unsafe fn init() -> std::result::Result<(), SetLoggerError> {
-    Simple::init(LevelFilter::Debug, Config::new(Some(time::Instant::now())))
+fn init() -> std::result::Result<(), SetLoggerError> {
+    logger::simple::Logger::init(LevelFilter::Debug, Config::new(Some(time::Instant::now())))
 }
 
 fn main() -> Result<()> {
-    unsafe {
-        init().unwrap();
-    }
     let cli = cli::generate();
+    init().unwrap();
 
     // LOGGER.
 
     if let Some(matches) = cli.subcommand_matches("server") {
         let config = matches.value_of("config").unwrap();
+        if let Some(file) = matches.value_of("log-file") {};
 
         log::info!("starting server");
         server::start(config)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,8 @@ mod shared;
 
 use log::{LevelFilter, SetLoggerError};
 use server::error;
-use shared::logger::Simple;
+use shared::logger::{Config, Simple};
+use std::time;
 
 type Result<T> = std::result::Result<T, error::Taskmaster>;
 
@@ -17,7 +18,7 @@ type Result<T> = std::result::Result<T, error::Taskmaster>;
 ///
 /// Will return `Err` when failing to initialise `LOGGER`
 unsafe fn init() -> std::result::Result<(), SetLoggerError> {
-    Simple::init(LevelFilter::Debug)
+    Simple::init(LevelFilter::Debug, Config::new(Some(time::Instant::now())))
 }
 
 fn main() -> Result<()> {

--- a/src/shared/logger/config.rs
+++ b/src/shared/logger/config.rs
@@ -1,0 +1,11 @@
+use std::time;
+
+pub struct Config {
+    pub instant: Option<time::Instant>,
+}
+
+impl Config {
+    pub fn new(instant: Option<time::Instant>) -> Self {
+        Self { instant }
+    }
+}

--- a/src/shared/logger/config.rs
+++ b/src/shared/logger/config.rs
@@ -1,5 +1,6 @@
 use std::time;
 
+#[derive(Clone, Copy, Debug)]
 pub struct Config {
     pub instant: Option<time::Instant>,
 }

--- a/src/shared/logger/file.rs
+++ b/src/shared/logger/file.rs
@@ -1,0 +1,43 @@
+use super::{write_log, Config};
+use log::{set_boxed_logger, set_max_level, LevelFilter, Log, Metadata, Record, SetLoggerError};
+use std::fs::File;
+use std::io::Write;
+use std::sync::Mutex;
+
+pub struct Logger {
+    level: LevelFilter,
+    config: Config,
+    file: Mutex<File>,
+}
+
+impl Logger {
+    pub fn init(level: LevelFilter, config: Config, file: File) -> Result<(), SetLoggerError> {
+        set_max_level(level);
+        set_boxed_logger(Self::new(level, config, file))
+    }
+
+    pub fn new(level: LevelFilter, config: Config, file: File) -> Box<Self> {
+        Box::new(Self {
+            level,
+            config,
+            file: Mutex::new(file),
+        })
+    }
+}
+
+impl Log for Logger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() <= self.level
+    }
+
+    fn log(&self, record: &Record) {
+        if self.enabled(record.metadata()) {
+            let mut file = self.file.lock().unwrap();
+            let _ = write_log(&self.config, record, &mut *file);
+        }
+    }
+
+    fn flush(&self) {
+        let _ = self.file.lock().unwrap().flush();
+    }
+}

--- a/src/shared/logger/mod.rs
+++ b/src/shared/logger/mod.rs
@@ -1,6 +1,7 @@
 pub mod config;
+pub mod file;
 pub mod simple;
 mod writer;
 
 pub use config::Config;
-pub use simple::Simple;
+use writer::write_log;

--- a/src/shared/logger/mod.rs
+++ b/src/shared/logger/mod.rs
@@ -1,0 +1,2 @@
+pub mod simple;
+pub use simple::Simple;

--- a/src/shared/logger/mod.rs
+++ b/src/shared/logger/mod.rs
@@ -1,2 +1,6 @@
+pub mod config;
 pub mod simple;
+mod writer;
+
+pub use config::Config;
 pub use simple::Simple;

--- a/src/shared/logger/simple.rs
+++ b/src/shared/logger/simple.rs
@@ -1,17 +1,20 @@
-use log::{Level, Metadata, Record};
+use log::{set_boxed_logger, LevelFilter, Metadata, Record, SetLoggerError};
 use std::time::Instant;
 
-pub static mut LOGGER: Simple = Simple {
-    level: Level::Debug,
-    now: None,
-};
-
 pub struct Simple {
-    pub level: Level,
+    pub level: LevelFilter,
     now: Option<Instant>,
 }
 
 impl Simple {
+    pub fn init(level: LevelFilter) -> Result<(), SetLoggerError> {
+        set_boxed_logger(Simple::new(level))
+    }
+
+    pub fn new(level: LevelFilter) -> Box<Self> {
+        Box::new(Self { level, now: None })
+    }
+
     pub fn set_instant(&mut self, instant: Instant) {
         self.now = Some(instant);
     }

--- a/src/shared/logger/simple.rs
+++ b/src/shared/logger/simple.rs
@@ -29,7 +29,7 @@ impl log::Log for Simple {
                 record.level(),
                 self.now.map_or(0, |time| time.elapsed().as_secs()),
                 record.args()
-            )
+            );
         }
     }
 

--- a/src/shared/logger/simple.rs
+++ b/src/shared/logger/simple.rs
@@ -1,16 +1,16 @@
-use super::{config::Config, writer::write_log};
-use log::{set_boxed_logger, set_max_level, LevelFilter, Metadata, Record, SetLoggerError};
+use super::{write_log, Config};
+use log::{set_boxed_logger, set_max_level, LevelFilter, Log, Metadata, Record, SetLoggerError};
 use std::io::stdout;
 
-pub struct Simple {
-    pub level: LevelFilter,
+pub struct Logger {
+    level: LevelFilter,
     config: Config,
 }
 
-impl Simple {
+impl Logger {
     pub fn init(level: LevelFilter, config: Config) -> Result<(), SetLoggerError> {
         set_max_level(level);
-        set_boxed_logger(Simple::new(level, config))
+        set_boxed_logger(Self::new(level, config))
     }
 
     pub fn new(level: LevelFilter, config: Config) -> Box<Self> {
@@ -18,15 +18,15 @@ impl Simple {
     }
 }
 
-impl log::Log for Simple {
+impl Log for Logger {
     fn enabled(&self, metadata: &Metadata) -> bool {
         metadata.level() <= self.level
     }
 
     fn log(&self, record: &Record) {
         if self.enabled(record.metadata()) {
-            let mut std = stdout();
-            let _ = write_log(&self.config, record, &mut std);
+            let std = stdout();
+            let _ = write_log(&self.config, record, &mut std.lock());
         }
     }
 

--- a/src/shared/logger/writer.rs
+++ b/src/shared/logger/writer.rs
@@ -1,0 +1,51 @@
+use super::config::Config;
+use log::{Level, Record};
+use std::{
+    io::{Error, Write},
+    time,
+};
+
+pub fn write_log<W>(config: &Config, record: &Record<'_>, writer: &mut W) -> Result<(), Error>
+where
+    W: Write,
+{
+    if config.instant.is_some() {
+        write_instant_with_level(writer, &config.instant.unwrap(), record.level())?;
+    } else {
+        write_level(writer, record.level())?;
+    }
+
+    write_args(writer, record)?;
+    Ok(())
+}
+
+#[inline(always)]
+fn write_instant_with_level<W>(
+    writer: &mut W,
+    instant: &time::Instant,
+    level: Level,
+) -> Result<(), Error>
+where
+    W: Write,
+{
+    write!(writer, "{:>5}[{:04}] ", level, instant.elapsed().as_secs())?;
+    Ok(())
+}
+
+#[inline(always)]
+fn write_level<W>(writer: &mut W, level: Level) -> Result<(), Error>
+where
+    W: Write,
+{
+    write!(writer, "[{:5}] ", level)?;
+    Ok(())
+}
+
+#[inline(always)]
+fn write_args<W>(writer: &mut W, record: &Record<'_>) -> Result<(), Error>
+where
+    W: Write,
+{
+    writeln!(writer, "{}", record.args())?;
+    Ok(())
+}


### PR DESCRIPTION
`taskmaster` now can log to file using option `--log-file` before **subcommand**

```shell
taskmaster --log-file output.log server --config ...
taskmaster --log-file output.log client ...
```
close #87 