### PR TITLE
Feature/add test for duplicate

### DIFF
--- a/features/config.feature
+++ b/features/config.feature
@@ -32,3 +32,24 @@ Feature: testing loading configuration file with taskmaster
     And we ask for tasks
     Then the server is still running
     And the server has read the tasks
+
+  @fixture.clean_server
+  Scenario: Test deleted task from config file
+    Given the config in "application/yaml"
+      """
+      test:
+        cmd: echo foo
+      rm:
+        cmd: echo bar
+      """
+    When the server is running
+    And we ask for tasks
+    Then the server has read the tasks
+    When we edit the current config file with
+      """
+      test:
+        cmd: echo foo
+      """
+    And we ask to reload the config
+    And we ask for tasks
+    Then the server has read the tasks

--- a/features/config_harden.feature
+++ b/features/config_harden.feature
@@ -1,0 +1,21 @@
+@fixture.setup_mimetypes
+@fixture.remove_tmp_files
+Feature: testing loading configuration with tricky use
+
+  Background: Setting option for taskmaster server
+    Given the verbose level as debug
+    And the format as "json"
+    And the log file as "config_harden.log"
+
+  @fixture.clean_server
+  Scenario: Load config with duplicated name
+    Given the config in "application/yaml"
+      """
+      test:
+        cmd: echo foo
+      test:
+        cmd: echo bar
+      """
+    When the server is running
+    And we sleep for 0.2
+    Then the server is still running

--- a/features/steps/assert_utils.py
+++ b/features/steps/assert_utils.py
@@ -49,6 +49,6 @@ def assert_tasks(got: Dict[str, Any], wanted: Dict[str, Any]):
         vgot = got.get(key)
         vwanted = wanted.get(key)
 
-        assert_true(vgot, msg_fmt=f'missing value for {key}')
-        assert_true(vwanted, msg_fmt=f'extra value from got with key {key}')
+        assert_true(vgot, msg_fmt=f'expected task with key "{key}"')
+        assert_true(vwanted, msg_fmt=f'unexpected task with key "{key}"')
         assert_task(got[key], wanted[key])

--- a/features/steps/given.py
+++ b/features/steps/given.py
@@ -1,22 +1,10 @@
-from os import remove
-from typing import Any, Callable, Union
+from features.steps.lib.utils import load_config_file
 from features.steps.lib.server_proc import ServerProc
 from features.steps.lib.client_proc import ClientProc
 from behave import given
 import logging
 
 log = logging.getLogger('given')
-
-
-def load_config_file(file: str, type: str):
-    if type == 'application/yaml':
-        import yaml
-        with open(file) as f:
-            return yaml.load(f, Loader=yaml.Loader)
-    elif type == 'application/toml':
-        import toml
-        with open(file) as f:
-            return toml.load(f)
 
 
 @given("the config file {file}")

--- a/features/steps/lib/utils.py
+++ b/features/steps/lib/utils.py
@@ -17,3 +17,14 @@ class NamespaceLock(Namespace):
         data = super().__getattr__(attr)
         self.lock.release()
         return data
+
+
+def load_config_file(file: str, type: str):
+    if type == 'application/yaml':
+        import yaml
+        with open(file) as f:
+            return yaml.load(f, Loader=yaml.Loader)
+    elif type == 'application/toml':
+        import toml
+        with open(file) as f:
+            return toml.load(f)

--- a/features/steps/when.py
+++ b/features/steps/when.py
@@ -1,3 +1,4 @@
+from features.steps.lib.utils import load_config_file
 from features.steps.lib.client_proc import ClientProc
 from behave import when
 from features.steps.lib.server_proc import ServerProc
@@ -67,3 +68,17 @@ def send_command(ctx, command):
     l.debug(f'command={command}')
     ctx.client.write(f'{command}\n')
     ctx.client.flush_in()
+
+
+@when('we edit the current config file with')
+def edit_current_config_file(ctx):
+    l = log.getChild(edit_current_config_file.__name__)
+    assert ctx.text is not None, 'we need a text to edit the config with'
+    assert 'config_file' in ctx, 'we need an existing config file loaded'
+    l.info(f'current_config={ctx.config_file}, data_size={len(ctx.text)}')
+    l.debug(f'text={ctx.text}')
+
+    with open(ctx.config_file, 'w') as f:
+        f.write(ctx.text)
+
+    ctx.config_data = load_config_file(ctx.config_file, ctx.config_type[0])

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -39,11 +39,8 @@ where
 }
 
 pub fn start(config: &str, format: &str) -> Result<(), error::Taskmaster> {
-    log::info!(
-        "starting server with config at {} and format {}",
-        config,
-        format
-    );
+    log::info!("starting server with config file {}", config,);
+    log::info!("message output format as {}", format);
     let format = MessageFormat::from_str(format).unwrap();
     match format {
         MessageFormat::Human => start_raw::<Human>(config),

--- a/src/server/monitor.rs
+++ b/src/server/monitor.rs
@@ -170,14 +170,11 @@ pub struct Monitor {
     finished: Vec<FinishedChild>,
 }
 
-// impl Drop for Monitor {
-//     fn drop(&mut self) {
-//         for child in &mut self.children {
-//             child.kill().expect("cannot kill children");
-//         }
-//         self.children.clear();
-//     }
-// }
+impl Drop for Monitor {
+    fn drop(&mut self) {
+        self.kill();
+    }
+}
 
 impl Monitor {
     // Only create Monitoring struct
@@ -279,6 +276,10 @@ impl Monitor {
             self.stopping.push(stopping_child);
         }
         self.running.clear();
+    }
+
+    pub fn kill(&mut self) {
+        log::info!("[{}] killing ...", self.id);
     }
 
     pub fn restart(&mut self) {

--- a/src/server/monitor.rs
+++ b/src/server/monitor.rs
@@ -176,7 +176,9 @@ pub struct Monitor {
 
 impl Drop for Monitor {
     fn drop(&mut self) {
-        self.kill();
+        if self.is_running() {
+            self.kill();
+        }
     }
 }
 

--- a/src/server/monitor.rs
+++ b/src/server/monitor.rs
@@ -89,6 +89,10 @@ impl RunningChild {
             self.stopdelay,
         ))
     }
+
+    fn kill(&mut self) -> std::io::Result<()> {
+        self.child.kill()
+    }
 }
 
 #[derive(Debug)]
@@ -279,7 +283,20 @@ impl Monitor {
     }
 
     pub fn kill(&mut self) {
+        let mut killed_cout = 0;
         log::info!("[{}] killing ...", self.id);
+
+        while !self.running.is_empty() {
+            let mut chld = self.running.remove(0);
+            killed_cout += 1;
+            chld.kill().expect("cannot kill child");
+        }
+        while !self.stopping.is_empty() {
+            let mut chld = self.stopping.remove(0);
+            killed_cout += 1;
+            chld.kill().expect("cannot kill chld");
+        }
+        log::info!("[{}] result of killing: {} killed", self.id, killed_cout);
     }
 
     pub fn restart(&mut self) {

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -59,7 +59,7 @@ impl<F: Formatter> State<F> {
             }
         }
         let mut monitors = self.monitors.lock().unwrap();
-        log::info!("removed task: {:?}", to_remove);
+        log::info!("removed task from config: {:?}", to_remove);
         while !to_remove.is_empty() {
             let taskid = to_remove.remove(0);
             monitors.remove(&taskid);

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -47,19 +47,26 @@ impl<F: Formatter> State<F> {
 
     pub fn reload(&mut self, watcher: &Watcher) {
         let configfile: ConfigFile = ConfigFile::try_from(watcher).unwrap();
+        let mut to_remove: Vec<String> = self.monitors.lock().unwrap().keys().cloned().collect();
 
         for (name, task) in configfile {
             log::debug!("parsed task: {}: {:?}", name, task);
 
             if self.monitors.lock().unwrap().get(&name).is_some() {
-                self.reload_task(&name, task);
+                self.may_reload_task(&name, task);
             } else {
                 self.add_task(&name, task);
             }
         }
+        let mut monitors = self.monitors.lock().unwrap();
+        log::info!("removed task: {:?}", to_remove);
+        while !to_remove.is_empty() {
+            let taskid = to_remove.remove(0);
+            monitors.remove(&taskid);
+        }
     }
 
-    fn reload_task(&mut self, name: &str, task: Task) {
+    fn may_reload_task(&mut self, name: &str, task: Task) {
         let mut monitors = self.monitors.lock().unwrap();
         let mon = monitors.get_mut(name).unwrap();
 

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -53,6 +53,7 @@ impl<F: Formatter> State<F> {
             log::debug!("parsed task: {}: {:?}", name, task);
 
             if self.monitors.lock().unwrap().get(&name).is_some() {
+                to_remove.retain(|taskid| taskid != &name);
                 self.may_reload_task(&name, task);
             } else {
                 self.add_task(&name, task);

--- a/src/server/task.rs
+++ b/src/server/task.rs
@@ -49,7 +49,7 @@ impl TryFrom<&Watcher> for ConfigFile {
                 log::error!("no handler for extension '{}'", ext);
                 Err(error::Taskmaster::Cli)
             }
-            _ => {
+            None => {
                 log::error!("cannot determine file type by extension");
                 Err(error::Taskmaster::Cli)
             }


### PR DESCRIPTION
How server handle duplicate task name in config file ?

the use of `serde` and `hashmap` for parsing result in with duplicate task name that only the last one taken into account

close #112 #113