### PR TITLE
correct behave fixture

### DIFF
--- a/features/fixture_lib.py
+++ b/features/fixture_lib.py
@@ -68,7 +68,12 @@ def setup_server_mock(ctx):
     import os
     l = log.getChild(setup_server_mock.__name__)
     l.debug('starting server mock')
-    os.unlink(TASKMASTER_SOCK)
+
+    try:
+        os.unlink(TASKMASTER_SOCK)
+    except FileNotFoundError as e:
+        l.info(f'{TASKMASTER_SOCK} not existing, skipping deletion: {e}')
+
     ServerMock.log = log.getChild(ServerMock.__name__)
     ctx.server_mock = ServerMock()
     ctx.server_mock.log = log.getChild(ServerMock.__name__)


### PR DESCRIPTION
correct behave failure on fixture `use_server_mock` when trying to delete non existing `taskmaster.sock`