### PR TITLE
add feature test state

### DIFF
--- a/features/server_harden.feature
+++ b/features/server_harden.feature
@@ -48,37 +48,3 @@ Feature: Test server on malicious use
     And we ask the status of "foo"
     And we sleep for 0.2
     Then the server is still running
-
-@fixture.setup_mimetypes
-@fixture.remove_tmp_files
-@fixture.use_client_mock
-Feature: Test task's state nightmare
-
-  Background: Setting option for taskmaster server
-    Given the verbose level as debug
-    And the format as "json"
-    And the log file as "server_hardening.log"
-
-  @fixture.clean_server
-  Scenario: Test autostart on reloading task
-    Given the config in "application/yaml"
-      """
-      test:
-        cmd: echo foo
-        autostart: false
-      """
-    When the server is running
-    And we ask the status of "test"
-    Then the status of "test" is "Inactive"
-    When we edit the current config file with
-      """
-      test:
-        cmd: echo foo
-        autostart: true
-      """
-    And we ask to reload the config
-    And we ask the status of "test"
-    Then the status of "test" is one of
-      | status   |
-      | Finished |
-      | Running  |

--- a/features/server_harden.feature
+++ b/features/server_harden.feature
@@ -3,48 +3,82 @@
 @fixture.use_client_mock
 Feature: Test server on malicious use
 
-    Background: Setting option for taskmaster server
-        Given the verbose level as debug
-        And the format as "json"
-        And the log file as "server_hardening.log"
-        Given the config in "application/yaml"
-            """
+  Background: Setting option for taskmaster server
+    Given the verbose level as debug
+    And the format as "json"
+    And the log file as "server_hardening.log"
+    Given the config in "application/yaml"
+      """
             test:
                 cmd: echo foo
                 stdout: /tmp/echo-test.out
-            """
+      """
 
-    @fixture.clean_server
-    Scenario: Test start on unknown task name
-        When the server is running
-        And we ask to start "foo"
-        And we sleep for 0.2
-        Then the server is still running
+  @fixture.clean_server
+  Scenario: Test start on unknown task name
+    When the server is running
+    And we ask to start "foo"
+    And we sleep for 0.2
+    Then the server is still running
 
-    @fixture.clean_server
-    Scenario: Test stop on unknown task name
-        When the server is running
-        And we ask to start "foo"
-        And we sleep for 0.2
-        Then the server is still running
+  @fixture.clean_server
+  Scenario: Test stop on unknown task name
+    When the server is running
+    And we ask to start "foo"
+    And we sleep for 0.2
+    Then the server is still running
 
-    @fixture.clean_server
-    Scenario: Test info on unknown task name
-        When the server is running
-        And we ask the info about "foo"
-        And we sleep for 0.2
-        Then the server is still running
+  @fixture.clean_server
+  Scenario: Test info on unknown task name
+    When the server is running
+    And we ask the info about "foo"
+    And we sleep for 0.2
+    Then the server is still running
 
-    @fixture.clean_server
-    Scenario: Test restart on unknown task name
-        When the server is running
-        And we ask to restart "foo"
-        And we sleep for 0.2
-        Then the server is still running
+  @fixture.clean_server
+  Scenario: Test restart on unknown task name
+    When the server is running
+    And we ask to restart "foo"
+    And we sleep for 0.2
+    Then the server is still running
 
-    @fixture.clean_server
-    Scenario: Test status on unknown task name
-        When the server is running
-        And we ask the status of "foo"
-        And we sleep for 0.2
-        Then the server is still running
+  @fixture.clean_server
+  Scenario: Test status on unknown task name
+    When the server is running
+    And we ask the status of "foo"
+    And we sleep for 0.2
+    Then the server is still running
+
+@fixture.setup_mimetypes
+@fixture.remove_tmp_files
+@fixture.use_client_mock
+Feature: Test task's state nightmare
+
+  Background: Setting option for taskmaster server
+    Given the verbose level as debug
+    And the format as "json"
+    And the log file as "server_hardening.log"
+
+  @fixture.clean_server
+  Scenario: Test autostart on reloading task
+    Given the config in "application/yaml"
+      """
+      test:
+        cmd: echo foo
+        autostart: false
+      """
+    When the server is running
+    And we ask the status of "test"
+    Then the status of "test" is "Inactive"
+    When we edit the current config file with
+      """
+      test:
+        cmd: echo foo
+        autostart: true
+      """
+    And we ask to reload the config
+    And we ask the status of "test"
+    Then the status of "test" is one of
+      | status   |
+      | Finished |
+      | Running  |

--- a/features/state_nightmare.feature
+++ b/features/state_nightmare.feature
@@ -1,0 +1,33 @@
+@fixture.setup_mimetypes
+@fixture.remove_tmp_files
+@fixture.use_client_mock
+Feature: Test task's state nightmare
+
+  Background: Setting option for taskmaster server
+    Given the verbose level as debug
+    And the format as "json"
+    And the log file as "server_hardening.log"
+
+  @fixture.clean_server
+  Scenario: Test autostart on reloading task
+    Given the config in "application/yaml"
+      """
+      test:
+        cmd: echo foo
+        autostart: false
+      """
+    When the server is running
+    And we ask the status of "test"
+    Then the status of "test" is "Inactive"
+    When we edit the current config file with
+      """
+      test:
+        cmd: echo foo
+        autostart: true
+      """
+    And we ask to reload the config
+    And we ask the status of "test"
+    Then the status of "test" is one of
+      | status   |
+      | Finished |
+      | Running  |

--- a/features/state_nightmare.feature
+++ b/features/state_nightmare.feature
@@ -6,7 +6,7 @@ Feature: Test task's state nightmare
   Background: Setting option for taskmaster server
     Given the verbose level as debug
     And the format as "json"
-    And the log file as "server_hardening.log"
+    And the log file as "state_nightmare.log"
 
   @fixture.clean_server
   Scenario: Test autostart on reloading task
@@ -26,8 +26,9 @@ Feature: Test task's state nightmare
         autostart: true
       """
     And we ask to reload the config
+    And we sleep for 0.2
     And we ask the status of "test"
     Then the status of "test" is one of
       | status   |
       | Finished |
-      | Running  |
+      | Active   |

--- a/features/steps/when_client_mock.py
+++ b/features/steps/when_client_mock.py
@@ -28,7 +28,7 @@ def status_task(ctx, taskname):
     status = ctx.client_mock.send_status(taskname)
     if 'task_status' not in ctx:
         ctx.task_status = {taskname: [status]}
-    elif ctx.task_status.has_key(taskname):
+    elif taskname in ctx.task_status:
         ctx.task_status[taskname].append(status)
     else:
         ctx.task_status[taskname] = [status]

--- a/src/server/monitor.rs
+++ b/src/server/monitor.rs
@@ -21,6 +21,7 @@ pub enum Status {
     Inactive,
     Active,
     Reloading,
+    Reloaded,
     Failing,
     Finished,
     Failed,
@@ -34,6 +35,7 @@ impl Display for Status {
             Status::Inactive => "inactive",
             Status::Active => "active",
             Status::Reloading => "reloading",
+            Status::Reloaded => "reloaded",
             Status::Failing => "failing",
             Status::Finished => "finished",
             Status::Failed => "failed",
@@ -264,10 +266,10 @@ impl Monitor {
             }
             self.task = task;
 
+            self.change_state(Status::Reloaded);
             if need_to_start {
                 self.start();
             } else {
-                // FIXME!: What if the monitor was started ?
                 self.change_state(Status::Inactive);
             }
         }
@@ -511,6 +513,7 @@ fn startable_state(state: Status) -> bool {
         || state == Status::Finished
         || state == Status::Failed
         || state == Status::Stopped
+        || state == Status::Reloaded
 }
 
 fn finished_state(state: Status) -> Status {
@@ -548,6 +551,7 @@ mod monitor_suite {
         assert_eq!(startable_state(Status::Failing), false);
         assert_eq!(startable_state(Status::Stopping), false);
 
+        assert_eq!(startable_state(Status::Reloaded), true);
         assert_eq!(startable_state(Status::Finished), true);
         assert_eq!(startable_state(Status::Inactive), true);
         assert_eq!(startable_state(Status::Failed), true);
@@ -560,6 +564,8 @@ mod monitor_suite {
         assert_eq!(finished_state(Status::Reloading), Status::Finished);
         assert_eq!(finished_state(Status::Finished), Status::Finished);
         assert_eq!(finished_state(Status::Inactive), Status::Finished);
+
+        assert_eq!(finished_state(Status::Reloaded), Status::Finished);
 
         assert_eq!(finished_state(Status::Failing), Status::Failed);
         assert_eq!(finished_state(Status::Failed), Status::Failed);


### PR DESCRIPTION
try to correct error when a task `reload` with the `autostart` enabled

## How to reproduce

1. test
2. 
```yaml
test:
  cmd: echo foo
  autostart: false
```

2. then start the server